### PR TITLE
Added activerecord-import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'uglifier', '>= 1.3.0'
 # gem 'mini_racer', platforms: :ruby
 
 # Use CoffeeScript for .coffee assets and views
+gem 'activerecord-import'
 gem 'bootstrap', '~> 4.1.1'
 gem 'bootstrap_form', git: 'https://github.com/bootstrap-ruby/bootstrap_form.git', branch: 'master'
 gem 'jquery-rails', '~> 4.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       activemodel (= 5.2.0)
       activesupport (= 5.2.0)
       arel (>= 9.0)
+    activerecord-import (0.23.0)
+      activerecord (>= 3.2)
     activestorage (5.2.0)
       actionpack (= 5.2.0)
       activerecord (= 5.2.0)
@@ -354,6 +356,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   aruba (= 0.14.2)
   better_errors
   bootsnap (>= 1.1.0)

--- a/spec/services/events/parse_csv_spec.rb
+++ b/spec/services/events/parse_csv_spec.rb
@@ -13,6 +13,13 @@ module Events
         expect(Event.count).to eq(7)
         expect(result).to be_valid
       end
+
+      it 'performance: one query only to insert everything' do
+        csv_path = './spec/fixtures/example.csv'
+
+        expect { described_class.new(csv_path: csv_path).call }
+          .to make_database_queries(count: 1, manipulative: true)
+      end
     end
 
     context 'error in parsing' do


### PR DESCRIPTION
Quick spec on speed gains when importing via activerecord-import, 1K lines, 3x-ish improvement

```
Events::ParseCsv
  happy path
Rehearsal -------------------------------------------------
am import       0.749154   0.266085   1.015239 (  1.156473)
not am import   2.625963   0.516289   3.142252 (  3.835429)
---------------------------------------- total: 4.157491sec

                    user     system      total        real
am import       0.815668   0.280948   1.096616 (  1.183028)
not am import   2.503028   0.491626   2.994654 (  3.587611)
```