### PR TITLE
When importing CSVs, do not use ActiveRecord to validate

### DIFF
--- a/spec/fixtures/nothing.csv
+++ b/spec/fixtures/nothing.csv
@@ -1,0 +1,1 @@
+1,IRRELEVANT,12345,"{\"customer_name\":\"Jack\",\"customer_address\":\"Trade St.\",\"status\":\"unpaid\"}"

--- a/spec/fixtures/unparseable_timestamp.csv
+++ b/spec/fixtures/unparseable_timestamp.csv
@@ -1,0 +1,1 @@
+1,Order,AN_UNPARSEABLE_TIMESTAMP,"{\"customer_name\":\"Jack\",\"customer_address\":\"Trade St.\",\"status\":\"unpaid\"}"

--- a/spec/services/events/parse_csv_spec.rb
+++ b/spec/services/events/parse_csv_spec.rb
@@ -34,14 +34,38 @@ module Events
         end
       end
 
-      context 'CSV, but error in parsing' do
-        it 'nothing gets persisted and an error is returned' do
-          csv_path = './spec/fixtures/incomplete_example.csv'
+      context 'actual CSV' do
+        context 'error in parsing the CSV file' do
+          it 'nothing gets persisted and an error is returned' do
+            csv_path = './spec/fixtures/incomplete_example.csv'
 
-          result = described_class.new(csv_path: csv_path).call
+            result = described_class.new(csv_path: csv_path).call
 
-          expect(Event.count).to eq(0)
-          expect(result).not_to be_valid
+            expect(Event.count).to eq(0)
+            expect(result).not_to be_valid
+          end
+        end
+
+        context 'failed object_type validator (not in possible object types)' do
+          it 'nothing gets persisted and an error is returned' do
+            csv_path = './spec/fixtures/nothing.csv'
+
+            result = described_class.new(csv_path: csv_path).call
+
+            expect(Event.count).to eq(0)
+            expect(result).not_to be_valid
+          end
+        end
+
+        context 'unparseable timestamp' do
+          it 'nothing gets persisted and an error is returned' do
+            csv_path = './spec/fixtures/unparseable_timestamp.csv'
+
+            result = described_class.new(csv_path: csv_path).call
+
+            expect(Event.count).to eq(0)
+            expect(result).not_to be_valid
+          end
         end
       end
     end


### PR DESCRIPTION
With this PR, the object import CSV script would:

- Skip the AR validations.
- Use a validation inside the service as to validate inclusion of object_type anyway.
- There is a database-level constraint on null object_ids, object_types which catches bypassing `validate_presence_of` in the `Event` model.

A quick benchmark shows 1.5 second improvement on 10K rows:
```
# Events::ParseCsv
#   happy path
# Rehearsal ---------------------------------------------
# validator off   2.005870   0.829379   2.835249 (  3.202471)
# validator on   4.108247   1.455430   5.563677 (  5.916823)

#                 user     system      total        real
# validator off   2.291721   0.864505   3.156226 (  4.469130)
# validator on   4.200368   1.447777   5.648145 (  5.973868)
```

- Also adds a validator for timestamp. We attempt to parse the timestamp via `Integer.parse` to catch `ArgumentErrors`.